### PR TITLE
ci(dependabot): auto-reconcile bun.lock on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,41 @@
+name: Dependabot lockfile sync
+
+# Dependabot bumps package.json but does not reconcile bun.lock, so the next
+# frozen install (CI, pre-push) fails on every Dependabot PR. This regenerates
+# bun.lock on the PR branch and commits it back via the shared reconcile-lockfile
+# action.
+#
+# The push uses a fine-grained PAT stored as a Dependabot secret
+# (DEPENDABOT_RECONCILE_TOKEN, Contents: write) so it re-triggers the required
+# `test` check on the new head; a GITHUB_TOKEN push would not, leaving the PR
+# unmergeable. Dependabot-triggered runs cannot read Actions secrets, which is
+# why the token lives in the Dependabot secret store. bun install --ignore-scripts
+# skips lifecycle scripts (including the Playwright browser fetch) while still
+# resolving bun.lock against the bumped manifest.
+on:
+  pull_request:
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+jobs:
+  reconcile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.DEPENDABOT_RECONCILE_TOKEN }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - uses: brettdavies/.github/actions/reconcile-lockfile@main
+        with:
+          command: bun install --ignore-scripts
+          files: bun.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,11 @@ lint, Prettier format check, typecheck, build, unit tests, and Playwright end-to
 Actions are SHA-pinned with a `# vX.Y.Z` trailing comment; keep them pinned. There is no `push` trigger — under squash
 merges the merge commit's tree equals the PR head CI already verified.
 
+`.github/workflows/dependabot-lockfile.yml` (workflow `Dependabot lockfile sync`) runs only on Dependabot PRs (`if:
+github.actor == 'dependabot[bot]'`). It regenerates `bun.lock` against the bumped `package.json` and commits it back via
+the shared `brettdavies/.github/actions/reconcile-lockfile` composite action, so the `test` check passes without a
+hand-reconciled lockfile. See Dependencies for the token it pushes with.
+
 ## Local hooks
 
 Hooks live at `scripts/hooks/`, activated per clone with `git config core.hooksPath scripts/hooks` (machine-local; does
@@ -109,3 +114,9 @@ actionlint, shellcheck). Keep the pre-push checks in lockstep with `test.yml`.
 Dependabot (`.github/dependabot.yml`) scans npm and github-actions weekly with a 7-day cooldown and targets `dev`. It
 never proposes major-version bumps; security updates are a separate path and still land. Bump majors deliberately, by
 hand.
+
+Dependabot bumps `package.json` but does not reconcile `bun.lock`, so a plain `bun install --frozen-lockfile` fails on
+every Dependabot PR. `dependabot-lockfile.yml` (see CI) regenerates and commits the lockfile automatically. The
+reconcile push needs a fine-grained PAT with `Contents: write`, stored as the `DEPENDABOT_RECONCILE_TOKEN` Dependabot
+secret (`gh secret set DEPENDABOT_RECONCILE_TOKEN --app dependabot`), because Dependabot-triggered runs cannot read
+Actions secrets and a `GITHUB_TOKEN` push would not re-trigger the required `test` check.


### PR DESCRIPTION
## Summary

Adds a Dependabot-only workflow that auto-reconciles `bun.lock`. Dependabot bumps `package.json` but leaves `bun.lock` stale, so `bun install --frozen-lockfile` (CI and the pre-push hook) fails on every Dependabot PR. The new `dependabot-lockfile.yml` regenerates `bun.lock` on the PR branch and commits it back through the shared `brettdavies/.github/actions/reconcile-lockfile` composite action, so the required `test` check passes without a hand-reconciled lockfile.

The reconcile push authenticates with a fine-grained PAT (`Contents: write`) stored as the `DEPENDABOT_RECONCILE_TOKEN` Dependabot secret, because Dependabot-triggered runs cannot read Actions secrets and a `GITHUB_TOKEN` push would not re-trigger the required `test` check on the new head. `bun install --ignore-scripts` skips lifecycle scripts (including the Playwright browser fetch) while still resolving the lockfile against the bumped manifest.

## Changes

- Add `.github/workflows/dependabot-lockfile.yml`: on Dependabot PRs to `dev`/`main`, regenerate and commit `bun.lock` via the shared reconcile action.
- Document the workflow and the `DEPENDABOT_RECONCILE_TOKEN` secret in `AGENTS.md` (CI and Dependencies).

## Type of Change

- [x] `ci`: CI/CD configuration changes

## Related Issues/Stories

- Story: n/a
- Issue: n/a
- Architecture: n/a
- Related PRs: brettdavies/.github#50 (the `reconcile-lockfile` action this calls)

## Testing

- [x] Manual testing completed

**Test Summary:**

- `actionlint` passes on the new workflow.
- The reconcile job only runs on Dependabot PRs (`if: github.actor == 'dependabot[bot]'`), so it does not affect this PR's checks. First live exercise is the next Dependabot PR, once #50 is on `.github` main and the secret is set.

## Files Modified

**Modified:**

- `AGENTS.md`

**Created:**

- `.github/workflows/dependabot-lockfile.yml`

**Deleted:**

- None.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [ ] No special deployment steps required
- [x] Deployment steps documented below:

Two prerequisites before this helps a real Dependabot PR: merge `brettdavies/.github#50` so `reconcile-lockfile@main` resolves, and set `DEPENDABOT_RECONCILE_TOKEN` (fine-grained PAT, `Contents: write`) as a Dependabot secret on this repo.

## Checklist

- [x] Code follows project conventions and style guidelines
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Self-review of code completed
- [x] No new warnings or errors introduced
- [x] Changes are backward compatible
