### PR TITLE
docs: correct stale references across repo markdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ A Bun workspaces monorepo:
 `apps/web` (the Astro app) builds to one Cloudflare Worker via the `@astrojs/cloudflare` adapter and targets two
 environments defined in `apps/web/wrangler.jsonc`:
 
-- **Staging** — Worker `lmgroktfy-staging` on `lmgroktfy-staging.workers.dev`. `bun run deploy:staging`.
+- **Staging** — Worker `lmgroktfy-staging` on the `dev.lmgroktfy.com` custom domain (workers.dev is disabled; Turnstile
+  refuses to issue a widget on the shared `*.workers.dev` zone). `bun run deploy:staging`.
 - **Production** — Worker `lmgroktfy` on the `lmgroktfy.com` / `www.lmgroktfy.com` custom domains. `bun run
   deploy:prod`.
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,15 @@ When someone opens a shared link, they'll see your question automatically submit
 This is a TypeScript monorepo using Bun workspaces:
 
 ```plaintext
+apps/
+└── web/        # Astro app on Cloudflare Workers (@astrojs/cloudflare)
 packages/
-├── shared/     # Shared types, schemas (Zod), constants, utilities
-├── client/     # Frontend application (TypeScript)
-└── web/        # Cloudflare Worker serving API + static assets
+└── shared/     # Shared types, schemas (Zod), constants, utilities
 ```
 
 ### Key Design Decisions
 
+- **Astro** - Site framework; the `@astrojs/cloudflare` adapter builds to a single Worker
 - **Bun** - Package manager and runtime
 - **TypeScript** - Strict mode enabled
 - **Zod** - Single source of truth for API types
@@ -149,7 +150,7 @@ of two targets:
 
 | Target     | Worker name         | Address                              | Command                  |
 | ---------- | ------------------- | ------------------------------------ | ------------------------ |
-| Staging    | `lmgroktfy-staging` | `lmgroktfy-staging.workers.dev`      | `bun run deploy:staging` |
+| Staging    | `lmgroktfy-staging` | `dev.lmgroktfy.com`                  | `bun run deploy:staging` |
 | Production | `lmgroktfy`         | `lmgroktfy.com`, `www.lmgroktfy.com` | `bun run deploy:prod`    |
 
 Production promotes **in place**: `deploy:prod` targets the existing `lmgroktfy` Worker that already holds the live
@@ -178,8 +179,8 @@ wrangler secret put TURNSTILE_SECRET_KEY --env production
 
 #### Release flow
 
-1. `bun run deploy:staging`, then verify `lmgroktfy-staging.workers.dev` (site renders, the API is gated, the cache
-   serves a repeat question).
+1. `bun run deploy:staging`, then verify `dev.lmgroktfy.com` (site renders, the API is gated, the cache serves a repeat
+   question).
 2. `bun run deploy:prod` promotes the verified build in place onto `lmgroktfy`.
 
 #### Rollback
@@ -197,9 +198,10 @@ Keep the last-known-good build deployable so a rollback never depends on recover
 
 Set these in Cloudflare Workers dashboard or `.dev.vars` for local development:
 
-| Variable      | Description          |
-| ------------- | -------------------- |
-| `XAI_API_KEY` | xAI API key for Grok |
+| Variable               | Description                     |
+| ---------------------- | ------------------------------- |
+| `API_KEY`              | xAI API key for Grok            |
+| `TURNSTILE_SECRET_KEY` | Cloudflare Turnstile secret key |
 
 ## Testing
 

--- a/RELEASES-RATIONALE.md
+++ b/RELEASES-RATIONALE.md
@@ -230,12 +230,13 @@ gh api repos/<owner>/<repo>/commits/<sha>/check-runs --jq '.check_runs[].name'
 `guard-provenance:`, `guard-release:`) chosen specifically so their published context strings are `guard-docs /
 check-forbidden-docs`, `guard-provenance / check-provenance`, and `guard-release / check-release-branch-name`.
 
-### Why lmgroktfy's rulesets aren't committed in-repo
+### Why lmgroktfy's rulesets are committed in-repo
 
-`Protect dev` and `Protect main` are applied directly via the GitHub API/UI rather than vendored as JSON under
-`.github/rulesets/`. Committing the spec (the pattern some brettdavies repos use) adds a review trail for ruleset
-changes; applying directly is fewer moving parts for a single-maintainer repo. The same `gh api -X POST/PUT
-repos/<owner>/<repo>/rulesets` calls in RELEASES.md work identically against a committed file if that changes.
+`Protect dev` and `Protect main` are versioned as JSON under `.github/rulesets/` (`protect-dev.json`,
+`protect-main.json`) and applied to GitHub via the API, not edited only in the web UI. Committing the spec makes it the
+source of truth: ruleset changes get a diff and a review trail instead of living as invisible account state, and the `gh
+api -X PUT repos/<owner>/<repo>/rulesets/<id> --input .github/rulesets/protect-main.json` recipe in
+[`RELEASES.md`](./RELEASES.md) reapplies an edited file verbatim.
 
 ## Related docs
 

--- a/docs/runbooks/astro-cloudflare-cutover.md
+++ b/docs/runbooks/astro-cloudflare-cutover.md
@@ -86,8 +86,8 @@ CANARY_XAI_API_KEY="$(op read 'op://secrets-dev/LM Grok TFY/API Key')" bun run s
 
 ## Bake window
 
-Leave the new build serving production for the agreed bake window before removing the legacy packages (U13). Watch the
-nightly canary and error rates across the window.
+Leave the new build serving production for the agreed bake window. Watch the nightly canary and error rates across the
+window.
 
 ## Rollback
 


### PR DESCRIPTION
## Summary

A full audit of the repo's in-tree markdown against the current Astro on Cloudflare Workers monorepo. Four docs had references that drifted from the code:

- `README.md`: the "Architecture" tree still showed the old `packages/{shared,client,web}` layout (`client` and `web` no longer exist; the app is `apps/web`), Key Design Decisions never mentioned Astro, the staging address was `lmgroktfy-staging.workers.dev` (workers.dev is disabled and Turnstile will not issue a widget there, so staging serves `dev.lmgroktfy.com`), and the environment-variable table named `XAI_API_KEY` (the actual secret is `API_KEY`) while omitting `TURNSTILE_SECRET_KEY`.
- `AGENTS.md`: same stale staging address, corrected to the `dev.lmgroktfy.com` custom domain with the workers.dev/Turnstile rationale.
- `docs/runbooks/astro-cloudflare-cutover.md`: the bake-window step referenced a completed one-time "remove legacy packages" task; dropped it so the runbook reads as a living operator doc.
- `RELEASES-RATIONALE.md`: a subsection claimed the branch-protection rulesets "aren't committed in-repo," which contradicts both `RELEASES.md` and the repo (`.github/rulesets/protect-dev.json` and `protect-main.json` are committed). Rewritten to state the real rationale: committed JSON is the diffable, reviewable source of truth.

`PROJECT.md`, the runbook's topology table, and `.github/pull_request_template.md` were audited and are accurate. `CHANGELOG.md` (generated, markdownlint-ignored) and `docs/plans/…migration-plan.md` (a point-in-time plan) were intentionally excluded.

## Changelog

### Documentation

- Correct stale references in `README.md`, `AGENTS.md`, the cutover runbook, and `RELEASES-RATIONALE.md` to match the current Astro/Cloudflare monorepo: staging domain, environment-variable names, monorepo layout, and committed rulesets.

## Type of Change

- [x] `docs`: Documentation update

## Related Issues/Stories

- Story: n/a
- Issue: n/a
- Architecture: n/a
- Related PRs: #23 (removed the orphaned test locale fixtures the same audit surfaced)

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests passing

**Test Summary:**

- `markdownlint-cli2` clean (0 errors) across all four changed files.
- Every corrected claim verified against source: `apps/web/wrangler.jsonc` (staging routes `dev.lmgroktfy.com`, `workers_dev: false`), `apps/web/src/env.d.ts` (`API_KEY`), `.github/rulesets/*.json` (both committed), `package.json` scripts.

## Files Modified

**Modified:**

- `README.md`
- `AGENTS.md`
- `docs/runbooks/astro-cloudflare-cutover.md`
- `RELEASES-RATIONALE.md`

**Created:**

- None.

**Renamed:**

- None.

**Deleted:**

- None.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment steps required

## Checklist

- [x] Code follows project conventions and style guidelines
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Self-review of code completed
- [ ] Tests added/updated and passing
- [x] No new warnings or errors introduced
- [x] Changes are backward compatible (or breaking changes documented)

## Additional Context

One related item is deliberately left out of this markdown-only PR: `apps/web/tests/unit/middleware.test.ts` still uses `lmgroktfy-staging.workers.dev` as a test origin. That is a code change, tracked separately from this docs audit.
