### PR TITLE
test(middleware): use dev.lmgroktfy.com as the staging host

### DIFF
--- a/apps/web/tests/unit/middleware.test.ts
+++ b/apps/web/tests/unit/middleware.test.ts
@@ -102,20 +102,18 @@ describe('cors middleware', () => {
     expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
 
-  test('allows a same-origin request on a host outside ALLOWED_DOMAINS (staging)', async () => {
-    const context = makeContext('https://lmgroktfy-staging.workers.dev/api/grok', {
+  test('allows a same-origin request on the staging host (dev.lmgroktfy.com)', async () => {
+    const context = makeContext('https://dev.lmgroktfy.com/api/grok', {
       method: 'POST',
-      origin: 'https://lmgroktfy-staging.workers.dev',
+      origin: 'https://dev.lmgroktfy.com',
     });
     const response = await asMiddleware(cors)(context, nextOk);
     expect(response.status).toBe(200);
-    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
-      'https://lmgroktfy-staging.workers.dev'
-    );
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://dev.lmgroktfy.com');
   });
 
   test('still rejects a cross-origin caller on the staging host with 403', async () => {
-    const context = makeContext('https://lmgroktfy-staging.workers.dev/api/grok', {
+    const context = makeContext('https://dev.lmgroktfy.com/api/grok', {
       method: 'POST',
       origin: 'https://evil.com',
     });
@@ -145,8 +143,8 @@ describe('cors middleware', () => {
 describe('securityHeaders middleware', () => {
   const nextHtml = async () => new Response('<html></html>', { status: 200 });
 
-  test('sets the static CSP with no nonce and no HSTS on the workers.dev host', async () => {
-    const context = makeContext('https://lmgroktfy-staging.workers.dev/');
+  test('sets the static CSP with no nonce and no HSTS on the staging host', async () => {
+    const context = makeContext('https://dev.lmgroktfy.com/');
     const response = await asMiddleware(securityHeaders)(context, nextHtml);
     const csp = response.headers.get('Content-Security-Policy');
     expect(csp).toBeTruthy();


### PR DESCRIPTION
## Summary

Three middleware unit-test cases used `lmgroktfy-staging.workers.dev` as the staging host: the same-origin CORS allow, the cross-origin reject on the staging host, and the non-production no-HSTS case. That host is disabled (`apps/web/wrangler.jsonc` sets `workers_dev: false`) and staging serves on the `dev.lmgroktfy.com` custom domain. This retargets the three cases at `dev.lmgroktfy.com`.

The middleware is host-agnostic for these properties (CORS is a same-origin check; HSTS is scoped to `PRODUCTION_DOMAINS`), so the assertions are unchanged; the tests now just reference the host the Worker actually serves. The stale host was surfaced by the doc audit in #24.

## Changelog

No user-facing changes; test-only.

## Type of Change

- [x] `test`: Adding or updating tests

## Related Issues/Stories

- Story: n/a
- Issue: n/a
- Architecture: n/a
- Related PRs: #24 (doc audit that surfaced the stale `workers.dev` host)

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests passing

**Test Summary:**

- `bun test ./apps/web/tests/unit/middleware.test.ts`: 26 pass, 0 fail.
- prettier `--check` clean on the changed file.

## Files Modified

**Modified:**

- `apps/web/tests/unit/middleware.test.ts`

**Created:**

- None.

**Renamed:**

- None.

**Deleted:**

- None.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment steps required

## Checklist

- [x] Code follows project conventions and style guidelines
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Self-review of code completed
- [x] Tests added/updated and passing
- [x] No new warnings or errors introduced
- [x] Changes are backward compatible (or breaking changes documented)

## Additional Context

With `workers.dev` gone, the retargeted CSP/no-HSTS case and the existing "no HSTS on the dev.lmgroktfy.com staging domain" case now both exercise `dev.lmgroktfy.com`: one asserts the detailed CSP shape, the other is the focused HSTS-scope check. Both are left in place to keep this PR scoped to the stale-host fix; they can be consolidated separately if preferred.
