### PR TITLE
ci(deps): pin the Playwright family in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,18 @@
 # so a just-published version has to survive a week before Dependabot proposes
 # it. npm minor + patch updates group into one PR per week.
 #
-# The `ignore` rule suppresses every major-version bump: no PR ever proposes a
-# breaking-version jump. Security updates are a separate path and still land
-# regardless, so a CVE fix that requires a major is not blocked. Bump majors
-# deliberately, by hand.
+# The wildcard `ignore` rule suppresses every major-version bump: no PR ever
+# proposes a breaking-version jump. Security updates are a separate path and
+# still land regardless, so a CVE fix that requires a major is not blocked.
+# Bump majors deliberately, by hand.
+#
+# The Playwright family (@playwright/*, playwright, playwright-core) is
+# exact-pinned to the version dotfiles provisions into
+# $PLAYWRIGHT_BROWSERS_PATH, so bumping it is a dotfiles job, not a per-repo
+# one: a client newer than the provisioned browsers fails e2e locally. Those
+# entries carry no `update-types`, which suppresses every version update rather
+# than majors alone, since an exact pin has no "in range" update Dependabot
+# would otherwise leave alone.
 #
 # Dependabot reads this file from the default branch (dev) and, with
 # `target-branch: dev`, opens its PRs against dev. This file is mirrored onto
@@ -58,6 +66,9 @@ updates:
       - dependency-name: '*'
         update-types:
           - version-update:semver-major
+      - dependency-name: '@playwright/*'
+      - dependency-name: 'playwright'
+      - dependency-name: 'playwright-core'
   - package-ecosystem: github-actions
     directory: '/'
     target-branch: dev


### PR DESCRIPTION
## Summary

Freezes the Playwright family at 1.61.1 by adding `@playwright/*`, `playwright`, and `playwright-core` to the npm ecosystem's `ignore` list in `.github/dependabot.yml`. The entries carry no `update-types`, so every version update is suppressed, not majors alone. An exact pin has no "in range" update Dependabot would otherwise leave alone, which is why the existing wildcard major-only rule did not stop #28 from proposing `@playwright/test` 1.62.1.

Browser binaries are provisioned system-wide into `$PLAYWRIGHT_BROWSERS_PATH` rather than downloaded per repo (`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` in `test.yml`, and the pre-push hook notes never to run `playwright install` locally). A client ahead of the provisioned browsers breaks e2e. Bumping Playwright is a coordinated change on the provisioning side, not a per-repo dependency bump.

All three names are covered deliberately: `@playwright/test` is the direct devDependency, and `playwright` plus `playwright-core` come in transitively at the same version. Leaving the transitive pair unpinned would let a lockfile-only bump desync them from the provisioned browsers.

Same three-entry shape already carried by `agentnative-site` and `meum-sites`.

## Changelog

## Type of Change

- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `docs`: Documentation update
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Maintenance tasks (dependencies, config, etc.)
- [x] `ci`: CI/CD configuration changes
- [ ] `style`: Code style/formatting changes
- [ ] `build`: Build system changes
- [ ] `BREAKING CHANGE`: Breaking API change (requires major version bump)

## Related Issues/Stories

- Story: n/a
- Issue: n/a
- Architecture: n/a
- Related PRs: #28 (proposes the `@playwright/test` 1.62.1 bump this config suppresses)

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests passing

**Test Summary:**

- Unit tests: unchanged, no code touched
- Integration tests: unchanged, no code touched
- Coverage: n/a

Config-only change. Verified the YAML parses and that the three ignore entries land under the npm ecosystem block.

## Files Modified

**Modified:**

- `.github/dependabot.yml`

**Created:**

- None.

**Renamed:**

- None.

**Deleted:**

- None.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment steps required

Dependabot reads its config from the default branch, `dev`, so the pin takes effect once this merges. #28 still carries the 1.62.1 bump in its current diff; comment `@dependabot recreate` on it after this lands to rebuild the group without Playwright.

## Checklist

- [x] Code follows project conventions and style guidelines
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Self-review of code completed
- [ ] Tests added/updated and passing
- [x] No new warnings or errors introduced
- [x] Changes are backward compatible (or breaking changes documented)
