### PR TITLE
release: v2.0.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,18 @@
 # so a just-published version has to survive a week before Dependabot proposes
 # it. npm minor + patch updates group into one PR per week.
 #
-# The `ignore` rule suppresses every major-version bump: no PR ever proposes a
-# breaking-version jump. Security updates are a separate path and still land
-# regardless, so a CVE fix that requires a major is not blocked. Bump majors
-# deliberately, by hand.
+# The wildcard `ignore` rule suppresses every major-version bump: no PR ever
+# proposes a breaking-version jump. Security updates are a separate path and
+# still land regardless, so a CVE fix that requires a major is not blocked.
+# Bump majors deliberately, by hand.
+#
+# The Playwright family (@playwright/*, playwright, playwright-core) is
+# exact-pinned to the version dotfiles provisions into
+# $PLAYWRIGHT_BROWSERS_PATH, so bumping it is a dotfiles job, not a per-repo
+# one: a client newer than the provisioned browsers fails e2e locally. Those
+# entries carry no `update-types`, which suppresses every version update rather
+# than majors alone, since an exact pin has no "in range" update Dependabot
+# would otherwise leave alone.
 #
 # Dependabot reads this file from the default branch (dev) and, with
 # `target-branch: dev`, opens its PRs against dev. This file is mirrored onto
@@ -58,6 +66,9 @@ updates:
       - dependency-name: '*'
         update-types:
           - version-update:semver-major
+      - dependency-name: '@playwright/*'
+      - dependency-name: 'playwright'
+      - dependency-name: 'playwright-core'
   - package-ecosystem: github-actions
     directory: '/'
     target-branch: dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.2] - 2026-08-10
+
 ## [2.0.1] - 2026-07-30
 
 ### Documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmgroktfy",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Let me Grok that for you",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Config-only release from `dev` onto `main`. Net diff versus `v2.0.1` is one file: `.github/dependabot.yml` gains three `ignore` entries freezing `@playwright/*`, `playwright`, and `playwright-core`, plus the release bookkeeping (version bump, CHANGELOG section).

Nothing in the deployed Worker changes. No source, test, or workflow file is touched.

Playwright browser binaries are provisioned machine-wide into `$PLAYWRIGHT_BROWSERS_PATH` rather than downloaded per repo, and the provisioned set is 1.61.1. `@playwright/test` is already exact-pinned to 1.61.1 in `apps/web/package.json`, but an exact pin has no in-range update for Dependabot to leave alone, so the existing wildcard major-only rule did not stop #28 from proposing 1.62.1. The new entries carry no `update-types`, suppressing every version update rather than majors alone.

The pin has been live on `dev` since #29. This release carries it to `main` so both branches hold the same Dependabot config.

Only the Dependabot commit is cherry-picked. The remaining `dev` commits are docs-only; a `git diff HEAD..origin/dev --name-only` filtered to non-`docs/` paths comes back empty.

## Changelog

## Type of Change

- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `docs`: Documentation update
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Maintenance tasks (dependencies, config, etc.)
- [x] `ci`: CI/CD configuration changes
- [ ] `style`: Code style/formatting changes
- [ ] `build`: Build system changes
- [ ] `BREAKING CHANGE`: Breaking API change (requires major version bump)

## Related Issues/Stories

- Story: n/a
- Issue: n/a
- Architecture: n/a
- Related PRs: #29 (the pin, merged to `dev`), #28 (the Playwright bump this suppresses)

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests passing

**Test Summary:**

- Unit tests: unchanged, no source touched
- Integration tests: unchanged, no source touched
- Coverage: n/a

## Files Modified

**Modified:**

- `.github/dependabot.yml`
- `package.json`
- `CHANGELOG.md`

**Created:**

- None.

**Renamed:**

- None.

**Deleted:**

- None.

## Key Details

The `## [2.0.2]` CHANGELOG section is empty by design. `cliff.toml` drops `ci`-typed commits, and this release ships exactly one, so the generator has nothing user-facing to emit. `release.yml` handles an empty section by falling back to a `Release v2.0.2` placeholder body.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment steps required

The tag push publishes a Release record and deploys nothing. Once this merges, tag `v2.0.2` and merge `main` back into `dev` per `RELEASES.md`. After the config is on `main`, #28 can be rebuilt with `@dependabot recreate` and will come back without the Playwright bump.

## Checklist

- [x] Code follows project conventions and style guidelines
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Self-review of code completed
- [ ] Tests added/updated and passing
- [x] No new warnings or errors introduced
- [x] Changes are backward compatible (or breaking changes documented)
